### PR TITLE
Minor bug fix with `basic_gga.ipynb`

### DIFF
--- a/docs/source/qcbasic/basic_gga.ipynb
+++ b/docs/source/qcbasic/basic_gga.ipynb
@@ -1471,7 +1471,7 @@
     "ao = np.zeros((20, ngrid, nao))\n",
     "g_start, g_end, g_mem = 0, 0, 2000\n",
     "for inner_ao, _, _, _ in ni.block_loop(mol, grids, nao, 3, g_mem):\n",
-    "    g_end = g_start + ao.shape[1]\n",
+    "    g_end = g_start + inner_ao.shape[1]\n",
     "    ao[:, g_start:g_end, :] = inner_ao\n",
     "    g_start = g_end"
    ]


### PR DESCRIPTION
In my attempt to reproduce the results in [basic_gga](https://py-xdh.readthedocs.io/zh_CN/latest/qcbasic/basic_gga.html), I noticed that a wrongly placed variable may lead to incorrect array shape. The bug has been addressed in this PR.

It is also worth mentioning that the `pyxdh` package installed with `pip` does not come with the validation files, which may raise an error in the following line

```python
ref_fchk = FormchkInterface(resource_filename("pyxdh", "Validation/gaussian/H2O2-B3LYP-freq.fchk"))
```

This could be resolved by modifying the file path, but I am not certain if this additional procedure should be highlighted in the original notebook.